### PR TITLE
portabel ->overdraagbaar

### DIFF
--- a/nl/criteria/make-the-codebase-reusable-and-portable.md
+++ b/nl/criteria/make-the-codebase-reusable-and-portable.md
@@ -6,9 +6,9 @@ order: 3
 description: Codebases die door meerdere partijen worden ontwikkeld en gebruikt, hebben meer kans op een langlevende community.
 ---
 
-# Maak de codebase herbruikbaar en portabel
+# Maak de codebase herbruikbaar en overdraagbaar
 
-Het maken van herbruikbare en portabele [code](../glossary.html#code) stelt beleidsmakers, ontwikkelaars en ontwerpers in staat om wat is ontwikkeld te hergebruiken, te testen, te verbeteren en die verbeteringen weer in te brengen, wat leidt tot betere kwaliteit, goedkoper onderhoud en hogere betrouwbaarheid.
+Het maken van herbruikbare en overdraagbare [code](../glossary.html#code) stelt beleidsmakers, ontwikkelaars en ontwerpers in staat om wat is ontwikkeld te hergebruiken, te testen, te verbeteren en die verbeteringen weer in te brengen, wat leidt tot betere kwaliteit, goedkoper onderhoud en hogere betrouwbaarheid.
 
 Het doordacht en doelgericht ontwerpen van een [codebase](../glossary.html#codebase) voor herbruikbaarheid zorgt ervoor dat de missie, visie en scope van de codebase door meerdere partijen wordt gedeeld. Codebases die door meerdere partijen worden ontwikkeld en gebruikt, hebben meer kans op een langlevende community.
 


### PR DESCRIPTION
portabel staat niet in van Dale
draagbaar zou vooral gaan om gebruik tijdens dragen, wat hier niet wordt bedoeld overdraagbaar lijkt me beter